### PR TITLE
Allow users to ignore SSL checks (allows for connection with mongodb cloud)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ But **note**, this doesn't mean you need to write your whole project in C# if yo
 | Method | Type | Description |
 | ------------- | ------------- | ------------- |
 |`Connect(hostIp : String)`|`MongoClient`|Connect to a server in order to retrieve a client. You can get the default `hostIp` with `MongoAPI.host`, which is `mongodb://127.0.0.1:27017`|
+|`Connect(hostIp : String, checkSslCertificate : Bool)`|`MongoClient`|Connect to a server in order to retrieve a client. If `checkSslCertificate` is set to `false` mongodb will connect without verifying SSL certificates|
 <br/>  
 
 **MongoClient**
@@ -100,7 +101,6 @@ But **note**, this doesn't mean you need to write your whole project in C# if yo
 |`InsertDocument(document : Dictionary, _id : String)`|`void`|Insert a `BSON` document in the collection, parsed by a GDScript `Dictionary`. **note:** the \_id is not mandatory, but it always needs to be `null`,`""` or `" "` if you don't want to define an \_id|
 |`InsertManyDocuments(document_list : Array<Dictionary>)`|`void`|Insert multiple `BSON` documents in the collection, parsed by an `Array` of GDScript different `Dictionary`|
 |`CountDocuments()`|`int`|Count the number of `Documents` in the `MongoCollection`|
-|`GetDocument(_id : String)`|`Dictionary`|Return a specific document as a `Dictionary`|
 |`GetDocument(_id : String)`|`Dictionary`|Return a specific document as a `Dictionary`|
 |`FindDocumentsBy(key : String, value : String)`|`Array<Dictionary>`|Return an `Array` of different `Dictionary` representing the documents that respect the query with the specified `key` and `value`|
 |`UpdateDocumentBy(key : String, oldValue : String, newValue : String)`|`void`|Update the first document found with a `key:value` query, replacing the `oldValue` with the `newValue`|

--- a/addons/MongoDB/MongoAPI.cs
+++ b/addons/MongoDB/MongoAPI.cs
@@ -11,13 +11,16 @@ public class MongoAPI : Node
     [Export]
     private String host = "mongodb://127.0.0.1:27017";
     private String addonPath = "res://addons/MongoDB/";
-    public _MongoClient Connect(String hostIp)
+    public _MongoClient Connect(String hostIp){
+        return this.Connect(hostIp, true);
+    }
+    public _MongoClient Connect(String hostIp, bool checkSslCertificate)
     {
         host = hostIp;
         var MongoClientScene = (PackedScene) ResourceLoader.Load(addonPath+"MongoClient/MongoClient.tscn");
         var ClientScene = MongoClientScene.Instance() as _MongoClient;
         AddChild(ClientScene);
-        ClientScene.LoadClient(new MongoClient(host), addonPath);
+        ClientScene.LoadClient(new MongoClient(host), addonPath, checkSslCertificate);
         ClientScene.Name = host;
         return ClientScene;
     }

--- a/addons/MongoDB/MongoClient/_MongoClient.cs
+++ b/addons/MongoDB/MongoClient/_MongoClient.cs
@@ -13,7 +13,7 @@ public class _MongoClient : Node
     private String addonPath;
     private MongoClient client;
 
-    public void LoadClient(MongoClient mongoClient, String path, bool checkSslCertificate = true)
+    public void LoadClient(MongoClient mongoClient, String path, bool checkSslCertificate)
     {
         client = mongoClient;
         addonPath = path;

--- a/addons/MongoDB/MongoClient/_MongoClient.cs
+++ b/addons/MongoDB/MongoClient/_MongoClient.cs
@@ -1,6 +1,7 @@
 using Godot;
 using Godot.Collections;
 using System;
+using System.Security.Authentication;
 using System.Collections.Generic;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -12,10 +13,21 @@ public class _MongoClient : Node
     private String addonPath;
     private MongoClient client;
 
-    public void LoadClient(MongoClient mongoClient, String path)
+    public void LoadClient(MongoClient mongoClient, String path, bool checkSslCertificate = true)
     {
         client = mongoClient;
         addonPath = path;
+       
+        if (!checkSslCertificate){
+			var settings = client.Settings.Clone();
+			settings.SslSettings = new SslSettings() {
+			CheckCertificateRevocation = true,
+			ServerCertificateValidationCallback = (sender, certificate, chain, errors) => true
+			};
+			
+			client = new MongoClient(settings);
+		}
+        
     }
 
     public Godot.Collections.Array<Dictionary> GetDatabaseList()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update readme for new parameter, allow a user to ignore SSL checks to connect to mongodb cloud

## What is the current behavior?

By default it is checking for an SSL signature which may not be present if you are using a user:password connection string

## What is the new behavior?

When connecting to an online database (namely mongodb cloud) you can now connect without issues by setting the new flag

